### PR TITLE
config: Add cluster to Pusher configuration

### DIFF
--- a/config/packages/pusher_php_server.yaml
+++ b/config/packages/pusher_php_server.yaml
@@ -5,3 +5,5 @@ services:
             - '%env(PUSHER_APP_KEY)%'
             - '%env(PUSHER_APP_SECRET)%'
             - '%env(PUSHER_APP_ID)%'
+            -
+              cluster: '%env(PUSHER_APP_CLUSTER)%'


### PR DESCRIPTION
Fourth argument of the Pusher service constructor is an array of options.
Setting the 'cluster' option with the value defined in dotenv files allows specifying clusters others than than the default 'mt1'.